### PR TITLE
FIXMEs, TODOs and grammar fixes

### DIFF
--- a/src/api/upload.ts
+++ b/src/api/upload.ts
@@ -14,7 +14,7 @@ export async function uploadFile(path: string): Promise<{ error: string | null; 
 
   if (size > maxUploadBytes) {
     return {
-      error: `Squid archive size is ${size} bytes, this excess the limit on file upload. Please try to reduce squid files`,
+      error: `The squid archive size is too large (${size} bytes), exceeding the limit of ${Math.round(maxUploadBytes/1_000_0000).toFixed(1)}M.`,
     };
   }
 


### PR DESCRIPTION
Found bugs/issues:
- Couldn't deploy after runnint `squid init`:
<img width="566" alt="Screenshot 2022-12-05 at 15 42 36" src="https://user-images.githubusercontent.com/8627422/205664893-e793826e-e5b2-4ac6-8fbc-e9dc07cfc521.png">
- We should probably use [inquirer](https://oclif.io/docs/prompting#inquirer) if not template is provided to ask the user directly which template to should be used. Always picking Substrate will confuse EVM users (and we hope there will be many)
